### PR TITLE
Added configuration for RetryingTransactionHelper

### DIFF
--- a/alfresco-tests/src/main/java/org/alfresco/mock/test/MockServiceRegistry.java
+++ b/alfresco-tests/src/main/java/org/alfresco/mock/test/MockServiceRegistry.java
@@ -148,7 +148,7 @@ public class MockServiceRegistry implements BeanFactoryAware, ServiceRegistry, E
 	@Override
 	public RetryingTransactionHelper getRetryingTransactionHelper() {
 		// TODO Auto-generated method stub
-		return null;
+		return transactionService.getRetryingTransactionHelper();
 	}
 
 	@Override

--- a/alfresco-tests/src/main/resources/test-context.xml
+++ b/alfresco-tests/src/main/resources/test-context.xml
@@ -96,6 +96,8 @@
 	<bean id="transactionService"
 		class="org.alfresco.mock.test.MockTransactionService" />
 	<alias name="transactionService" alias="TransactionService" />
+	<bean id="retryingTransactionHelper" class="org.alfresco.mock.test.MockRetryingTransactionHelper"/>
+	<alias name="retryingTransactionHelper" alias="RetryingTransactionHelper"/>
 	<bean id="baseJavaScriptExtension" abstract="true" />
 	<bean id="dictionaryModelBootstrap"
 		class="org.alfresco.repo.dictionary.DictionaryBootstrap"


### PR DESCRIPTION
Hi,
I've fixed the getRetryingTransactionHelper method in the MockServiceRegistry class. Now it returns `transactionService.getRetryingTransactionHelper()` instead of `null`. I've also added the Spring bean for MockRetryingTransactionHelper.